### PR TITLE
Enhance ESlint configuration and remove experimental flag in next config

### DIFF
--- a/frontend/ui/.eslintrc.json
+++ b/frontend/ui/.eslintrc.json
@@ -1,3 +1,7 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules":{
+    "indent": ["error", 2],
+    "quotes": ["error", "double"]
+  }
 }

--- a/frontend/ui/app/about/page.tsx
+++ b/frontend/ui/app/about/page.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React from "react";
 
 export default function AboutPage() {
-    return (
-        <div>
-            <h1>About Pawsitive</h1>
-        </div>
-    );
+  return (
+    <div>
+      <h1>About Pawsitive</h1>
+    </div>
+  );
 }

--- a/frontend/ui/app/components/Navbar.tsx
+++ b/frontend/ui/app/components/Navbar.tsx
@@ -1,17 +1,25 @@
-import React from 'react';
-import Link from 'next/link';
+import React from "react";
+import Link from "next/link";
 
 const Navbar = () => {
-    return (
-        <nav>
-            <ul>
-                <li><Link href="/home">Home</Link></li>
-                <li><Link href="/about">About</Link></li>
-                <li><Link href="/shop">Shop</Link></li>
-                <li><Link href="/contact">Contact</Link></li>
-            </ul>
-        </nav>
-    );
+  return (
+    <nav>
+      <ul>
+        <li>
+          <Link href="/home">Home</Link>
+        </li>
+        <li>
+          <Link href="/about">About</Link>
+        </li>
+        <li>
+          <Link href="/shop">Shop</Link>
+        </li>
+        <li>
+          <Link href="/contact">Contact</Link>
+        </li>
+      </ul>
+    </nav>
+  );
 };
 
 export default Navbar;

--- a/frontend/ui/app/contact/page.tsx
+++ b/frontend/ui/app/contact/page.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React from "react";
 
 export default function ContactPage() {
-    return (
-        <div>
-            <h1>Sup brother </h1>
-        </div>
-    );
+  return (
+    <div>
+      <h1>Sup brother </h1>
+    </div>
+  );
 }

--- a/frontend/ui/app/home/page.tsx
+++ b/frontend/ui/app/home/page.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React from "react";
 
 export default function HomePage() {
-    return (
-        <div>
-            <h1>Welcome!</h1>
-        </div>
-    );
+  return (
+    <div>
+      <h1>Welcome!</h1>
+    </div>
+  );
 }

--- a/frontend/ui/app/layout.tsx
+++ b/frontend/ui/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./styles/globals.css";
-import Navbar from './components/Navbar';
+import Navbar from "./components/Navbar";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -15,12 +15,12 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-    return (
-        <html lang="en">
-            <body className={inter.className}>
-                <Navbar/>
-                    {children}
-            </body>
-        </html>
-    );
+  return (
+    <html lang="en">
+      <body className={inter.className}>
+        <Navbar />
+        {children}
+      </body>
+    </html>
+  );
 }

--- a/frontend/ui/app/shop/page.tsx
+++ b/frontend/ui/app/shop/page.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React from "react";
 
 export default function ShopPage() {
-    return (
-        <main>
-            <h1>Shop</h1>
-            <p>Get your Pawsitive Collar</p>
-        </main>
-    );
+  return (
+    <main>
+      <h1>Shop</h1>
+      <p>Get your Pawsitive Collar</p>
+    </main>
+  );
 }

--- a/frontend/ui/next.config.mjs
+++ b/frontend/ui/next.config.mjs
@@ -1,9 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    reactStrictMode: true,
-    experimental: {
-        appDir: true,
-    },
+  reactStrictMode: true,
 };
 
 export default nextConfig;


### PR DESCRIPTION
extend ESlint configuration to check for indentation and enforce double quotation marks for consistency. Experimental flag on appDir got removed from nextConfig, since it is a standard now.

> "This option is no longer needed as of Next.js 13.4. The App Router is now stable."
[hint on appDir Documentation](https://nextjs.org/docs/app/api-reference/next-config-js/appDir)