### PR TITLE
Normalize pet names, remove emojis to ensure GSM-7 encoding

### DIFF
--- a/backend/pawsitive/src/main/java/com/pawsitive/pawsitive/messaging/sms/twillio/service/TwilioSmsService.java
+++ b/backend/pawsitive/src/main/java/com/pawsitive/pawsitive/messaging/sms/twillio/service/TwilioSmsService.java
@@ -4,6 +4,7 @@ import com.pawsitive.pawsitive.dto.ScannedLocationDTO;
 import com.pawsitive.pawsitive.exception.SmsSendFailException;
 import com.pawsitive.pawsitive.geolocation.model.ScannedLocation;
 import com.pawsitive.pawsitive.messaging.mailing.service.SendGridEmailService;
+import com.pawsitive.pawsitive.util.string.StringUtil;
 import com.twilio.Twilio;
 import com.twilio.rest.api.v2010.account.Message;
 import com.twilio.type.PhoneNumber;
@@ -57,6 +58,6 @@ public class TwilioSmsService implements SmsService {
         ResourceBundle bundle = ResourceBundle.getBundle("messages", locale);
         String template = bundle.getString("sms.message");
         String mapsUrl = String.format("https://www.google.com/maps?q=%s,%s", lat, lon);
-        return String.format(template, petName, mapsUrl);
+        return String.format(template, StringUtil.removeAccent(petName), mapsUrl);
     }
 }

--- a/backend/pawsitive/src/main/java/com/pawsitive/pawsitive/util/string/StringUtil.java
+++ b/backend/pawsitive/src/main/java/com/pawsitive/pawsitive/util/string/StringUtil.java
@@ -1,0 +1,10 @@
+package com.pawsitive.pawsitive.util.string;
+
+import java.text.Normalizer;
+
+public class StringUtil {
+    public static String removeAccent(String text) {
+        return Normalizer.normalize(text, Normalizer.Form.NFD)
+                .replaceAll("\\p{M}", "");
+    }
+}

--- a/backend/pawsitive/src/main/resources/messages_de.properties
+++ b/backend/pawsitive/src/main/resources/messages_de.properties
@@ -1,1 +1,1 @@
-sms.message=Dein Haustier, %s wurde gefunden!🎉 \n📍Hier sind die Koordinaten:\n%s\n- Dein Pawsitive Collar Team🐾
+sms.message=Dein Haustier, %s wurde gefunden!\nHier ist der Standort:\n%s\n- Dein Pawsitive Collar Team

--- a/backend/pawsitive/src/main/resources/messages_en.properties
+++ b/backend/pawsitive/src/main/resources/messages_en.properties
@@ -1,1 +1,1 @@
-sms.message=Your pet, %s was found by someone!🎉 \n📍Here the coordinates:\n%s\n- Your Pawsitive Collar Team🐾
+sms.message=Your pet, %s was found by someone!\nHere is the location:\n%s\n- Your Pawsitive Collar Team

--- a/backend/pawsitive/src/main/resources/messages_hu.properties
+++ b/backend/pawsitive/src/main/resources/messages_hu.properties
@@ -1,1 +1,1 @@
-sms.message=Kiskedvenced, %s megkerült!🎉 \n📍Itt a helyszín:\n%s\n- A Pawsitive Collar Csapat🐾
+sms.message=Kiskedvenced, %s meglett!\nItt a helyszin:\n%s\n- A Pawsitive Collar Csapat


### PR DESCRIPTION
- Normalized accented characters in pet names (e.g., Béla → Bela) to avoid UCS-2 encoding.
- Removed emojis from localized SMS templates to reduce message cost and prevent encoding issues.
- Ensures all SMS messages stay within GSM-7 charset for optimal delivery and pricing.