### PR TITLE
Clear NFC tagId after first pet registration

### DIFF
--- a/frontend/ui/app/[locale]/profile/(profile_content)/(petTab)/AddPetCard.tsx
+++ b/frontend/ui/app/[locale]/profile/(profile_content)/(petTab)/AddPetCard.tsx
@@ -34,7 +34,9 @@ interface PetCardsProps {
 const AddPetCard = ({ profile, setProfile }: PetCardsProps) => {
   const searchParams = useSearchParams();
   const tagIdInUrl = searchParams.get("tagId");
-  const sanitizedTagId = tagIdInUrl === "null" ? "" : tagIdInUrl ?? "";
+  const [tagConsumed, setTagConsumed] = useState(false);
+  const sanitizedTagId =
+    !tagConsumed && tagIdInUrl !== "null" ? tagIdInUrl ?? "" : "";
 
   const [isEditMode, setIsEditMode] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -63,13 +65,11 @@ const AddPetCard = ({ profile, setProfile }: PetCardsProps) => {
     const response = await toast.promise(
       addPetAPI(createdPetDetail),
       {
-        pending: "Updating pet...",
+        pending: "Adding pet...",
         success: {
           render({ data }: { data: PetDTO }) {
-            return (
-              "Tag has been successfully linked to " + data.name + " 🎉" ||
-              "Something went wrong!"
-            );
+            setTagConsumed(true);
+            return "Tag has been successfully linked to " + data.name + " 🎉";
           },
         },
         error: {
@@ -103,7 +103,6 @@ const AddPetCard = ({ profile, setProfile }: PetCardsProps) => {
       };
 
       const savedPet: PetDTO = await addPet(newPet);
-      console.log(savedPet);
 
       if (imageCropResult) {
         const { compressedFile, fileName } = imageCropResult;


### PR DESCRIPTION
- Prevents reusing the same tagId from the URL when adding multiple pets
- Introduced `tagConsumed` state to only prefill NFC tagId once
- Ensures subsequent "Add Pet" actions start with an empty NFC field