### PR TITLE
Overwrite system font color to default black

### DIFF
--- a/frontend/ui/app/[locale]/profile/(profile_content)/(petTab)/AddPetCard.module.css
+++ b/frontend/ui/app/[locale]/profile/(profile_content)/(petTab)/AddPetCard.module.css
@@ -96,6 +96,7 @@
   align-items: center;
   justify-content: center;
   border: 1px solid transparent;
+  color: black;
 }
 
 .submitBtn:hover,

--- a/frontend/ui/app/[locale]/profile/(profile_content)/(userTab)/UserTab.module.css
+++ b/frontend/ui/app/[locale]/profile/(profile_content)/(userTab)/UserTab.module.css
@@ -148,6 +148,7 @@
   transition: all 0.1s linear;
   background-color: var(--color-pink-mid);
   margin-top: 1rem;
+  color: black;
 }
 
 .save_edit:hover {


### PR DESCRIPTION
- on iOS the pet edit buttons had system default blue colour; this defaults now to black for more pleasant look