### PR TITLE
Make CORS configuration dynamic for multiple environments

### DIFF
--- a/backend/pawsitive/src/main/java/com/pawsitive/pawsitive/config/WebConfig.java
+++ b/backend/pawsitive/src/main/java/com/pawsitive/pawsitive/config/WebConfig.java
@@ -5,19 +5,28 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.Arrays;
+import java.util.stream.Stream;
+
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
     @Value("${CORS_ALLOWED_ORIGINS_TEST}")
-    private String CORS_ALLOWED_ORIGINS_TEST;
+    private String corsAllowedOriginsTest;
 
     @Value("${CORS_ALLOWED_ORIGINS_PROD}")
-    private String CORS_ALLOWED_ORIGINS_PROD;
+    private String corsAllowedOriginsProd;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
+        // Combine allowed origins into a single array
+        String[] allowedOrigins = Stream.of(corsAllowedOriginsTest, corsAllowedOriginsProd)
+                .flatMap(s -> Arrays.stream(s.split(",")))
+                .map(String::trim)
+                .toArray(String[]::new);
+
         registry.addMapping("/**")
-                .allowedOrigins("http://10.0.0.136:3000", "http://localhost:3000",
-                        CORS_ALLOWED_ORIGINS_PROD, CORS_ALLOWED_ORIGINS_TEST)
+                .allowedOrigins(allowedOrigins)
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);


### PR DESCRIPTION
- Use environment variables to define allowed origins for test and production
- Support multiple domains, including www and root domains
- Remove hardcoded origins from Java code
- Ensures CORS works correctly for Vercel staging and production deployments