### PR TITLE
Handle OS level location tracking ban

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Next.js: debug server-side",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "npm run dev",
+      "cwd": "${workspaceFolder}/frontend/ui"
+    },
+    {
+      "name": "Next.js: debug client-side",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:3000",
+      "cwd": "${workspaceFolder}/frontend/ui"
+    },
+    {
+      "name": "Next.js: debug full stack",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/frontend/ui/node_modules/next/dist/bin/next",
+      "runtimeArgs": ["--inspect"],
+      "skipFiles": ["<node_internals>/**"],
+      "serverReadyAction": {
+        "action": "debugWithEdge",
+        "killOnServerStop": true,
+        "pattern": "- Local:.+(https?://.+)",
+        "uriFormat": "%s",
+        "webRoot": "${workspaceFolder}/frontend/ui"
+      },
+      "cwd": "${workspaceFolder}/frontend/ui"
+    }
+  ]
+}

--- a/frontend/ui/app/[locale]/pet/ScannedPetDetail.tsx
+++ b/frontend/ui/app/[locale]/pet/ScannedPetDetail.tsx
@@ -38,6 +38,7 @@ const ScannedPetDetail = () => {
 
   const handleLocationPermission = (info: PetInformationDTO) => {
     if (petId == null) return;
+    if (petInformation == null) return;
     setShowLocationPrompt(false);
 
     navigator.geolocation.getCurrentPosition(
@@ -71,6 +72,10 @@ const ScannedPetDetail = () => {
       },
       (error) => {
         console.warn("Standort konnte nicht ermittelt werden: ", error);
+        saveScannedLocation({
+          pet: petInformation.petDTO,
+          locale,
+        });
       },
       {
         enableHighAccuracy: true,


### PR DESCRIPTION
If the user has set the location tracking to be off on the OS level, the application now handles the silent fail and sends the request to the backend, hence the owner get notified in this edge-case as well

Also add launch.json to debug vercel application